### PR TITLE
model name configuration options added in env file for openai and gemini

### DIFF
--- a/server/.env.template
+++ b/server/.env.template
@@ -66,5 +66,7 @@ breakpoint_threshold_amount=None
 number_of_chunks=None
 
 use_openai=False
+openai_model_name='gpt-4o-mini'
 use_gemini=False
+gemini_model_name='gemini-pro'
 use_azure=False

--- a/server/RAGHelper_cloud.py
+++ b/server/RAGHelper_cloud.py
@@ -61,14 +61,14 @@ class RAGHelperCloud:
     def __init__(self, logger):
         if os.getenv("use_openai") == "True":
             self.llm = ChatOpenAI(
-                model="gpt-3.5-turbo",
+                model=os.getenv("openai_model_name"),
                 temperature=0,
                 max_tokens=None,
                 timeout=None,
                 max_retries=2,
             )
         elif os.getenv("use_gemini") == "True":
-            self.llm = ChatGoogleGenerativeAI(model="gemini-pro", convert_system_message_to_human=True)
+            self.llm = ChatGoogleGenerativeAI(model=os.getenv("gemini_model_name"), convert_system_message_to_human=True)
         elif os.getenv("use_azure") == "True":
             self.llm = AzureChatOpenAI(
                 openai_api_version=os.environ["AZURE_OPENAI_API_VERSION"],


### PR DESCRIPTION
The model name for openai and gemini is fixed in '`server/RAGHelper_cloud.py`'. 
I've added support to allow setting and changing name of model for openai and gemini using .env file.

Please review and let me know if any changes are required.

Thanks