### PR TITLE
fixed langchain_experimental no module text_splitter 

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,7 @@
 langchain==0.2.11
 langchain-community==0.2.10
-langchain-core==0.2.24
-langchain_experimental==0.0.6
+langchain-core==0.2.29
+langchain_experimental==0.0.64
 langchain-huggingface==0.0.3
 langchain-postgres==0.0.9
 langchain-text-splitters==0.2.1


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/arslan/Data/Learning/side_projects/RAGMeUp/server/server.py", line 5, in <module>
    from RAGHelper_cloud import RAGHelperCloud
  File "/home/arslan/Data/Learning/side_projects/RAGMeUp/server/RAGHelper_cloud.py", line 9, in <module>
    from langchain_experimental.text_splitter import SemanticChunker
ModuleNotFoundError: No module named 'langchain_experimental.text_splitter'

Solution:
langchain-core==0.2.29
langchain_experimental==0.0.64
