### PR TITLE
Fix typing error in requirements.txt

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -8,7 +8,7 @@ langchain-text-splitters==0.2.1
 langchain-milvus==0.1.3
 langchain-google-genai==1.0.7
 langchain-openai==0.1.9
-langchain-ollama=0.1.1
+langchain-ollama==0.1.1
 sentence-transformers==2.6.1
 transformers==4.43.1
 bitsandbytes==0.42.0


### PR DESCRIPTION
missing "==" in requirements.txt for installing langchain-ollama